### PR TITLE
v0.4.3 updated docs, pagination fix, config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,10 +273,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "half"
@@ -289,6 +327,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +343,16 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is-terminal"
@@ -340,6 +394,16 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+]
 
 [[package]]
 name = "lock_api"
@@ -404,6 +468,12 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -504,6 +574,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,15 +615,19 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ricat"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "base64",
  "clap",
  "criterion",
  "crossterm",
+ "dirs",
  "memmap2",
  "regex",
+ "serde",
+ "serde_json",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -568,18 +653,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -588,12 +673,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
  "serde",
 ]
 
@@ -678,6 +772,40 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -934,3 +1062,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ricat"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Aditya Navphule <adityanav@duck.com>"]
 description = "A Rust-Based implemenation of classic UNIX `cat` command"
@@ -8,6 +8,7 @@ repository = "https://github.com/adityanav123/ricat"
 license = "MIT"
 keywords = ["cat", "cli", "text-processing", "file", "system-tools"]
 documentation = "https://adityanav123.github.io/ricat"
+build = "build.rs"
 
 [[bin]]
 name = "ricat"
@@ -21,8 +22,10 @@ base64 = "0.22.0"
 thiserror = "1.0.59"
 criterion = "0.5.1"
 memmap2 = "0.9.4"
+serde = { version = "1.0.202", features = ["derive"] }
+serde_json = "1.0.117"
+toml = "0.8.13"
+dirs = "5.0.1"
 
-# [lib]
-# name = "ricat"
-# path = "src/main.rs"
-# crate-type = ["rlib"]
+[build-dependencies]
+dirs = "5.0.1"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ ricat --search --text "string_to_search" my_file.txt
 For regular expression searches, ensure the pattern is a valid regex. For example, to find lines containing digits:
 
 ```bash
-ricat --search --text "reg:\d+" my_file.txt
+ricat --search --text "reg:\\d+" my_file.txt
 ```
 
 For ignoring case sensitivity, use the `--ignore-case` or `-i` flag:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cargo install ricat --force
 - **Multiple File Support**: Concatenate and process multiple files specified as command-line arguments.
 - **Standard Input Processing**: Read from standard input when no file arguments are provided, allowing `ricat` to be used in command pipelines.
 - **Pagination**: Display the output in a paginated manner based on the terminal window size using the `--pages` flag.
+- **Presets**: Now Ricat uses ricat_cfg.toml file to store the presets for the features. You can change the presets according to your needs. It is stores in $HOME/.config/ricat/ricat_cfg.toml
 
 These features make `ricat` a versatile tool for text processing and manipulation, providing a range of functionalities to enhance your command-line workflows.
 
@@ -130,6 +131,18 @@ Example of encoding and then decoding the string "And"
 ricat --help
 ```
 
+## Configuration Presets
+Config file for ricat is stored in $HOME/.config/ricat/ricat_cfg.toml. You can change the presets for the features in this file. The file is created when you run the ricat command for the first time.
+
+Defaults: 
+
+```toml
+number_feature = false
+dollar_sign_feature = false
+tabs_feature = false
+compress_empty_line_feature = false
+```    
+
 ## Benchmarking
 
 `ricat` provides benchmark scripts to compare its performance with the standard cat and a previous version of `ricat` already installed.
@@ -182,6 +195,12 @@ Contributions are most welcome! If you have ideas for new features or improvemen
 To report bugs, you can go to the [GitHub Discussions](https://github.com/adityanav123/ricat/discussions/11#discussion-6424900)
 
 ## Release Notes
+
+### 0.4.3
+- Added support for configuration presets for the features in the ricat_cfg.toml file.
+- Added ability to quit pagination mode by pressing `q` key.
+- fixes & improvements.
+- Updated Documentation for the project.
 
 ### 0.4.2
 - Added support for Memory Mapped IO, improves performance times by almost 150% for reading files directly without any features applied.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let config_dir = out_dir.join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+
+    let default_cfg = r#"
+number_feature = false
+dollar_sign_feature = false
+tabs_feature = false
+compress_empty_line_feature = false
+    "#;
+
+    let config_file = config_dir.join("ricat_cfg.toml");
+    fs::write(&config_file, default_cfg).unwrap();
+
+    let home_dir = dirs::home_dir().expect("Failed to find home directory");
+    let target_config_dir = home_dir.join(".config/ricat");
+    fs::create_dir_all(&target_config_dir).expect("Failed to create target config directory");
+
+    let target_config_file = target_config_dir.join("ricat_cfg.toml");
+    fs::copy(&config_file, &target_config_file).expect("Failed to copy config file");
+
+    println!(
+        "cargo:rustc-env=RICAT_CONFIG_DIR={}",
+        target_config_dir.display()
+    );
+    println!(
+        "ricat configuration file created at: {}",
+        target_config_file.display()
+    );
+    std::io::stdout().flush().unwrap();
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,36 @@
+use serde::Deserialize;
+use std::env;
+use std::path::PathBuf;
+use std::fs::{create_dir_all, read_to_string};
+
+/// Config struct
+#[derive(Deserialize, Debug, Default)]
+pub struct RicatConfig {
+    pub number_feature: bool,
+    pub dollar_sign_feature: bool,
+    pub tabs_feature: bool,
+    pub compress_empty_line_feature: bool,
+    pub pagination_feature: bool,
+}
+
+/// Loading the config from $HOME/.config/ricat/ricat_cfg.toml
+pub fn load_config() -> RicatConfig {
+    let config_dir = env::var("RICAT_CONFIG_DIR").unwrap_or_else(|_| {
+        let home_dir = dirs::home_dir().expect("Failed to find home directory");
+        let default_config_dir = home_dir.join(".config/ricat");
+        create_dir_all(&default_config_dir).expect("Failed to create config directory");
+        default_config_dir.to_str().unwrap().to_string()
+    });
+
+    let config_file = PathBuf::from(config_dir).join("ricat_cfg.toml");
+
+    if config_file.exists() {
+        if let Ok(config_content) = read_to_string(config_file) {
+            if let Ok(config) = toml::from_str(&config_content) {
+                return config;
+            }
+        }
+    }
+
+    RicatConfig::default()
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -129,4 +129,12 @@ pub enum RicatError {
     /// It includes a string message providing more details about the error.
     #[error("Error writing data to writer via Memory Mapped IO: {0}")]
     MemoryMapWriteError(String),
+
+    /// Represents an Error when reading the config file
+    #[error("Error reading config file: {0}")]
+    ConfigReadError(String),
+
+    /// User Quits the Pagination Mode by pressing 'q'
+    #[error("User Quit Pagination Mode")]
+    UserQuit,
 }


### PR DESCRIPTION
1. docs update
2. ricat can now read from config file stored in users $HOME/.config/ricat folder , named : ricat_cfg.toml
3. can now quit pagination mode, by pressing 'q' key while in pagination mode.